### PR TITLE
Fix Blank Window In VTK 9.0.2xxxxxx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,27 +9,33 @@ set (APP_VERSION_MINOR 0)
 set (EXECNAME imgui_vtk)
 
 
-find_package(VTK COMPONENTS 
-  vtkCommonCore
-  vtkCommonDataModel
-  vtkFiltersCore
-  vtkInteractionStyle
-  vtkRenderingCore
-  vtkRenderingFreeType
-  vtkRenderingGL2PSOpenGL2
-  vtkRenderingOpenGL2
+find_package(ParaView
   QUIET
 )
-
-if (NOT VTK_FOUND)
-  message("Skipping ImageDataToQImage: ${VTK_NOT_FOUND_MESSAGE}")
-  return ()
+if (NOT ParaView_FOUND)
+  find_package(VTK COMPONENTS 
+    CommonCore
+    CommonColor
+    CommonDataModel
+    FiltersCore
+    InteractionStyle
+    RenderingCore
+    RenderingFreeType
+    RenderingGL2PSOpenGL2
+    RenderingOpenGL2
+    QUIET
+  )
+  if (NOT VTK_FOUND)
+    message("Skipping imgui-vtk: ${VTK_NOT_FOUND_MESSAGE}")
+    return ()
+  endif()
 endif()
+
 message (STATUS "VTK_VERSION: ${VTK_VERSION}")
 
 # glfw
 list (APPEND CMAKE_MODULE_PATH "${${PROJECT_NAME}_SOURCE_DIR}")
-find_package(GLFW3 REQUIRED)
+find_package(glfw3 REQUIRED)
 include_directories(${GLFW3_INCLUDE_DIR})
 link_libraries(${GLFW_LIBRARY_DIRS})
 
@@ -55,6 +61,8 @@ target_include_directories (${EXECNAME}
     "${${PROJECT_NAME}_SOURCE_DIR}/imgui"
 )
 
+target_compile_definitions(${EXECNAME} PRIVATE "IMGUI_IMPL_OPENGL_LOADER_GLAD")
+
 if (UNIX)
   if (APPLE)
       target_link_libraries (
@@ -63,6 +71,7 @@ if (UNIX)
               "-framework IOKit"
               "-framework CoreVideo"
               glfw
+              OpenGL::GL
               ${VTK_LIBRARIES}
       )
   else ()
@@ -72,6 +81,7 @@ if (UNIX)
               ${X11_LIBRARIES}
               ${CMAKE_DL_LIBS}
               glfw
+              OpenGL::GL
               ${VTK_LIBRARIES}
       )
   endif()

--- a/imgui_impl_vtk.cpp
+++ b/imgui_impl_vtk.cpp
@@ -237,13 +237,13 @@ void    ImGui_ImplVTK_Render(const std::string& title)
     ImGui_ImplVTK_SetVportSize(ImGui::GetWindowSize().x, ImGui::GetWindowSize().y);
 #if VTK_MAJOR_VERSION >= 9
 #if VTK_BUILD_VERSION >= 2
-    glBindFramebuffer(GL_DRAW_BUFFER, g_FBOHdl); // required since we set BlitToCurrent = On.
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, g_FBOHdl); // required since we set BlitToCurrent = On.
 #endif // VTK_BUILD_VERSION >= 2
 #endif // VTK_MAJOR_VERSION >= 9
     g_RenderWindow->Render();
 #if VTK_MAJOR_VERSION >= 9
 #if VTK_BUILD_VERSION >= 2
-    glBindFramebuffer(GL_DRAW_BUFFER, 0);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 #endif // VTK_BUILD_VERSION >= 2
 #endif // VTK_MAJOR_VERSION >= 9
 


### PR DESCRIPTION
#### CMakeLists.txt
- Try to locate ParaView's VTK.
- Force glad.
- Link to OpenGL::GL on unix
#### imgui_impl_vtk.cpp
- Fix typo in enum. Caused OpenGL error. 1280: Invalid enum in VTK >= 9.0.2
